### PR TITLE
Добавлена возможность добавлять парметры в CustomComand

### DIFF
--- a/jquery.wysibb.js
+++ b/jquery.wysibb.js
@@ -1050,7 +1050,8 @@
 							if (selHTML=="") {
 								//open empty tag
 								$.log("open empty tag");
-								var crnode = createElementFromString(wbbStringFormat("{htmlOpen}\uFEFF{htmlClose}",{htmlOpen:opt.htmlOpen,htmlClose:opt.htmlClose}));
+								var crnodeTpl = wbbStringFormat("{htmlOpen}\uFEFF{htmlClose}",{htmlOpen:opt.htmlOpen,htmlClose:opt.htmlClose})
+								var crnode = createElementFromString(wbbStringFormat(crnodeTpl, params));
 								$(crnode).attr("wbb","true");
 								var snode = selection.getNode();
 								
@@ -1099,7 +1100,8 @@
 								//end clear
 								
 								selHTML = el.innerHTML;
-								var resel = createElementFromString(wbbStringFormat("{htmlOpen}{txt}{htmlClose}",{htmlOpen:opt.htmlOpen,htmlClose:opt.htmlClose,txt:selHTML}));
+								var reselTpl = wbbStringFormat("{htmlOpen}{txt}{htmlClose}", {htmlOpen:opt.htmlOpen,htmlClose:opt.htmlClose});
+								var resel = createElementFromString(wbbStringFormat(reselTpl,$.extend({txt:selHTML}, params)));
 								
 								if (replaceNode) {
 									$(replaceNode).replaceWith(resel);


### PR DESCRIPTION
```
1. Добавлена возможность добавлять парметры в CustomComand.
   Например что бы можно было вставить [video]{src}, а src получить через prompt
2. Исправлен баг при создании комманд. Раньше все аргументы превращались в строки.
   Сейчас используется eval, хотя комманды по прежнему лежат в commandList.
```
