### PR TITLE
Added processor property to bb code options.

### DIFF
--- a/jquery.wysibb.js
+++ b/jquery.wysibb.js
@@ -2016,7 +2016,8 @@ wbbdebug=true;
 			$.each(this.options.btnlist,$.proxy(function(i,b){
 				if (b!="|" && b!="-") {
 					var find=true;
-					if (!this.options.allButtons[b] || !this.options.allButtons[b].transform) {
+					var button = this.options.allButtons[b];
+					if (!button || !button.transform) {
 						return true;
 					}
 
@@ -2041,6 +2042,10 @@ wbbdebug=true;
 								$.each(a,$.proxy(function(i,k) {
 									r[k]=am[i+1];
 								},this));
+								r = this.keysToLower(r);
+								if (button.processor) {
+									button.processor(r);
+								}
 								var nhtml = html;
 								nhtml = nhtml.replace(/\{(.*?)(\[.*?\])\}/g,"{$1}");
 								nhtml = this.strf(nhtml,r);


### PR DESCRIPTION
If present, processor method is called when converting bb to html. It may calculate additional properties. For example, [link={ID}]{SELTEXT}[/link] may be converted to <a href="{URL}" data-link-id="{ID}">{SELTEXT}</a>, where URL property is somehow calculated (and cached if possible for performance reasons). Notice, that initial ID property should also be stored to perform transform back to bb code.
Processor code for this example:
processor: function(data) { data.link = '/link?id=' + data.id; }
