### PR TITLE
Fix for #184

### DIFF
--- a/jquery.wysibb.js
+++ b/jquery.wysibb.js
@@ -2089,7 +2089,7 @@ wbbdebug=true;
 								var nhtml = html;
 								nhtml = nhtml.replace(/\{(.*?)(\[.*?\])\}/g,"{$1}");
 								nhtml = this.strf(nhtml,r);
-								bbdata = bbdata.replace(am[0],nhtml);
+								bbdata = bbdata.replace(am[0],function(){return nhtml});
 							}
 						}
 					},this));


### PR DESCRIPTION
`${` converts to `$&#123;`
And the bug occurs when the [special replacement pattern](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter) `$&` (that inserts the matched substring) is passed to the second argument of the `replace` method (which is inside while loop) on this line:
 ```bbdata = bbdata.replace(am[0],nhtml);```
But when specifying a function as second parameter in `replace` method, replacement patterns will not apply.
